### PR TITLE
修改自动匹配键值仅匹配数字、修正flv格式视频无法识别的bug

### DIFF
--- a/SubRenamer/Action.cs
+++ b/SubRenamer/Action.cs
@@ -1,17 +1,10 @@
-﻿using Microsoft.WindowsAPICodePack.Dialogs;
-using System;
-using System.Collections;
+﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using static SubRenamer.Global;
@@ -107,7 +100,7 @@ namespace SubRenamer
             }
         }
 
-        private void UpdateFileListUiItem (ListViewItem item)
+        private void UpdateFileListUiItem(ListViewItem item)
         {
             if (item.Tag == null) return;
             var itemValues = GetItemValues((VsItem)item.Tag);
@@ -147,7 +140,7 @@ namespace SubRenamer
         // 自动匹配配置
         private int M_Auto_Begin = int.MinValue;
         private string M_Auto_End = null;
-        
+
         // 手动匹配配置
         public string M_Manu_V_Begin = null;
         public string M_Manu_V_End = null;
@@ -170,14 +163,14 @@ namespace SubRenamer
                 string matchKey = GetMatchKeyByFileName(file.Name, FileType, FileList);
 
                 var findVsItem = (matchKey != null) ? VsList.Find(o => o.MatchKey == matchKey) : null; // By matchKey
-                
+
                 if (findVsItem == null)
                     findVsItem = VsList.Find(o =>
                     {
                         if (FileType == AppFileType.Video) return o.Video == file.FullName;
                         if (FileType == AppFileType.Sub) return o.Sub == file.FullName;
                         return false;
-                     }); // 通过文件名查找到的现成的 VsItem
+                    }); // 通过文件名查找到的现成的 VsItem
 
                 // 仅更新数据
                 if (findVsItem != null)
@@ -287,8 +280,23 @@ namespace SubRenamer
 
             result = result.TrimStart('0'); // 开头为零的情况：替换 0001 为 1
             result = result.Trim(); // 去掉前后空格
+            
+            string ans = "";
+            bool sflag = false;
+            foreach (var i in result)
+            {
 
-            return result;
+                if (i >= '0' && i <= '9')
+                {
+                    sflag = true;
+                    ans += i.ToString();
+                }
+                else if (sflag)
+                {
+                    break;
+                }
+            }
+            return ans;
         }
 
         // 遍历所有 list 中的项目，尝试得到集数开始位置
@@ -347,7 +355,8 @@ namespace SubRenamer
             if (list.Count() < 2) return null;
             if (beginPos <= -1) return null;
 
-            string fileName = list.Where(o => {
+            string fileName = list.Where(o =>
+            {
                 if (o.Name == null || o.Name.Length <= beginPos) return false;
                 return Regex.IsMatch(o.Name.Substring(beginPos)[0].ToString(), @"^\d+$");
             }).ToList()[0].Name; // 获取开始即是数字的文件名
@@ -386,7 +395,8 @@ namespace SubRenamer
             Program.Log($"[=============== 开始执行改名操作  ===============]");
 
             string btnRawText = "";
-            Invoke((MethodInvoker)delegate {
+            Invoke((MethodInvoker)delegate
+            {
                 StartBtn.Enabled = false;
                 btnRawText = StartBtn.Text;
                 StartBtn.Text = "改名中...";
@@ -431,7 +441,8 @@ namespace SubRenamer
             if (errTotal > 0)
                 Process.Start(LOG_FILENAME);
 
-            Invoke((MethodInvoker)delegate {
+            Invoke((MethodInvoker)delegate
+            {
                 StartBtn.Text = btnRawText;
                 StartBtn.Enabled = true;
             });

--- a/SubRenamer/AppSettings.cs
+++ b/SubRenamer/AppSettings.cs
@@ -37,17 +37,29 @@ namespace SubRenamer
         #region Utils
         public static IniFile IniFile = new IniFile();
 
-        private static bool GetBoolVal(bool defaultVal = false, [CallerMemberName]string key = null)
+        private static bool GetBoolVal(bool defaultVal = false, [CallerMemberName] string key = null)
         {
             if (string.IsNullOrWhiteSpace(key)) return defaultVal;
             string defaultValStr = defaultVal ? "1" : "0";
             return IniFile.Read(key, defaultValStr).Equals("1");
         }
 
-        private static void WriteBoolVal(bool val, [CallerMemberName]string key = null)
+        private static void WriteBoolVal(bool val, [CallerMemberName] string key = null)
         {
             if (string.IsNullOrWhiteSpace(key)) return;
             IniFile.Write(key, val ? "1" : "0");
+        }
+
+        public static List<string> GetExtensionList(string listString)
+        {
+            List<string> list = listString.Split('|').ToList();
+            return list;
+        }
+
+        public static string GetStringVal(string defaultVal = null, [CallerMemberName] string key = null)
+        {
+            if (string.IsNullOrWhiteSpace(key)) return defaultVal;
+            return IniFile.Read(key, defaultVal);
         }
         #endregion
     }

--- a/SubRenamer/Global.cs
+++ b/SubRenamer/Global.cs
@@ -12,8 +12,8 @@ namespace SubRenamer
     {
         #region 常量
         public static readonly string LOG_FILENAME = Path.Combine(Application.StartupPath, $"{Program.GetAppName()}.log");
-        public static readonly List<string> VideoExts = new List<string> { ".mkv", ".mp4", ".flv", ".avi", ".mov", ".rmvb", ".wmv", ".mpg", ".avs" };
-        public static readonly List<string> SubExts = new List<string> { ".srt", ".ass", ".ssa", ".sub", ".idx" };
+        public static List<string> VideoExts = new List<string> { ".mkv", ".mp4", ".flv", ".avi", ".mov", ".rmvb", ".wmv", ".mpg", ".avs" };
+        public static List<string> SubExts = new List<string> { ".srt", ".ass", ".ssa", ".sub", ".idx" };
         #endregion
 
         /// <summary>

--- a/SubRenamer/Global.cs
+++ b/SubRenamer/Global.cs
@@ -12,8 +12,8 @@ namespace SubRenamer
     {
         #region 常量
         public static readonly string LOG_FILENAME = Path.Combine(Application.StartupPath, $"{Program.GetAppName()}.log");
-        public static List<string> VideoExts = new List<string> { ".mkv", ".mp4", ".flv", ".avi", ".mov", ".rmvb", ".wmv", ".mpg", ".avs" };
-        public static List<string> SubExts = new List<string> { ".srt", ".ass", ".ssa", ".sub", ".idx" };
+        public static HashSet<string> VideoExts = new HashSet<string> { ".mkv", ".mp4", ".flv", ".avi", ".mov", ".rmvb", ".wmv", ".mpg", ".avs" };
+        public static HashSet<string> SubExts = new HashSet<string> { ".srt", ".ass", ".ssa", ".sub", ".idx" };
         #endregion
 
         /// <summary>

--- a/SubRenamer/Global.cs
+++ b/SubRenamer/Global.cs
@@ -12,7 +12,7 @@ namespace SubRenamer
     {
         #region 常量
         public static readonly string LOG_FILENAME = Path.Combine(Application.StartupPath, $"{Program.GetAppName()}.log");
-        public static readonly List<string> VideoExts = new List<string> { ".mkv", ".mp4", "flv", ".avi", ".mov", ".rmvb", ".wmv", ".mpg", ".avs" };
+        public static readonly List<string> VideoExts = new List<string> { ".mkv", ".mp4", ".flv", ".avi", ".mov", ".rmvb", ".wmv", ".mpg", ".avs" };
         public static readonly List<string> SubExts = new List<string> { ".srt", ".ass", ".ssa", ".sub", ".idx" };
         #endregion
 

--- a/SubRenamer/Lib/InputBox.cs
+++ b/SubRenamer/Lib/InputBox.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace SubRenamer.Lib
+{
+    class InputBox
+    {
+
+        /// <summary>
+        /// 在 C# 中也可以用類似 VB.NET 的 InputBox(彈出式輸入方塊)
+        /// </summary>
+        /// <see cref="https://dotblogs.com.tw/aquarius6913/2014/09/03/146444"/>
+        /// <param name="title"></param>
+        /// <param name="promptText"></param>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static DialogResult Input(string title, string promptText, ref string value)
+        {
+            Form form = new Form();
+            Label label = new Label();
+            TextBox textBox = new TextBox();
+            Button buttonOk = new Button();
+            Button buttonCancel = new Button();
+
+            form.Text = title;
+            label.Text = promptText;
+            textBox.Text = value;
+
+            buttonOk.Text = "OK";
+            buttonCancel.Text = "Cancel";
+            buttonOk.DialogResult = DialogResult.OK;
+            buttonCancel.DialogResult = DialogResult.Cancel;
+
+            label.SetBounds(9, 20, 372, 13);
+            textBox.SetBounds(12, 36, 372, 20);
+            buttonOk.SetBounds(228, 72, 75, 23);
+            buttonCancel.SetBounds(309, 72, 75, 23);
+
+            label.AutoSize = true;
+            textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
+            buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+
+            form.ClientSize = new System.Drawing.Size(396, 107);
+            form.Controls.AddRange(new Control[] { label, textBox, buttonOk, buttonCancel });
+            form.ClientSize = new System.Drawing.Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+            form.FormBorderStyle = FormBorderStyle.FixedDialog;
+            form.StartPosition = FormStartPosition.CenterScreen;
+            form.MinimizeBox = false;
+            form.MaximizeBox = false;
+            form.AcceptButton = buttonOk;
+            form.CancelButton = buttonCancel;
+
+            DialogResult dialogResult = form.ShowDialog();
+            value = textBox.Text;
+            return dialogResult;
+        }
+    }
+}
+

--- a/SubRenamer/MainForm.Designer.cs
+++ b/SubRenamer/MainForm.Designer.cs
@@ -84,10 +84,10 @@
             this.CopyrightText.Dock = System.Windows.Forms.DockStyle.Bottom;
             this.CopyrightText.Font = new System.Drawing.Font("微软雅黑", 8F);
             this.CopyrightText.ForeColor = System.Drawing.Color.DarkGray;
-            this.CopyrightText.Location = new System.Drawing.Point(7, 670);
+            this.CopyrightText.Location = new System.Drawing.Point(7, 684);
             this.CopyrightText.Margin = new System.Windows.Forms.Padding(7, 10, 7, 10);
             this.CopyrightText.Name = "CopyrightText";
-            this.CopyrightText.Size = new System.Drawing.Size(176, 30);
+            this.CopyrightText.Size = new System.Drawing.Size(176, 16);
             this.CopyrightText.TabIndex = 10;
             this.CopyrightText.Text = "(c) qwqaq.com";
             this.CopyrightText.Click += new System.EventHandler(this.CopyrightText_Click);
@@ -141,9 +141,9 @@
             // 
             this.PreviewCheckBox.AutoSize = true;
             this.PreviewCheckBox.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.PreviewCheckBox.Location = new System.Drawing.Point(3, 714);
+            this.PreviewCheckBox.Location = new System.Drawing.Point(3, 728);
             this.PreviewCheckBox.Name = "PreviewCheckBox";
-            this.PreviewCheckBox.Size = new System.Drawing.Size(184, 35);
+            this.PreviewCheckBox.Size = new System.Drawing.Size(184, 21);
             this.PreviewCheckBox.TabIndex = 17;
             this.PreviewCheckBox.Text = "改名预览";
             this.PreviewCheckBox.UseVisualStyleBackColor = true;
@@ -377,7 +377,7 @@
             // 
             // MainForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(14F, 31F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1484, 844);
             this.Controls.Add(this.MainContWrapPanel);

--- a/SubRenamer/MainForm.cs
+++ b/SubRenamer/MainForm.cs
@@ -1,17 +1,12 @@
-﻿using System;
-using System.Collections;
+﻿using Microsoft.WindowsAPICodePack.Dialogs;
+using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
-using Microsoft.WindowsAPICodePack.Dialogs;
 using static SubRenamer.Global;
 
 namespace SubRenamer
@@ -32,7 +27,7 @@ namespace SubRenamer
 
         private void InitFileExtensionSetting()
         {
-            SettingForm.LoadDefaultExtensions();
+            SettingForm.LoadExtensions();
         }
 
         // 窗口加载完后

--- a/SubRenamer/MainForm.cs
+++ b/SubRenamer/MainForm.cs
@@ -26,10 +26,15 @@ namespace SubRenamer
 
             UpdateWinTitle();
             SettingForm = new SettingForm(this); // 设置窗体
-
+            InitFileExtensionSetting();
             InitShorcut(); // 初始化快捷键
         }
-        
+
+        private void InitFileExtensionSetting()
+        {
+            SettingForm.LoadDefaultExtensions();
+        }
+
         // 窗口加载完后
         private void MainForm_Load(object sender, EventArgs e)
         {
@@ -58,7 +63,11 @@ namespace SubRenamer
                 Multiselect = true,
             })
             {
-                fbd.Filters.Add(new CommonFileDialogFilter("视频或字幕文件", string.Join(";", VideoExts.Concat(SubExts).ToList())));
+                fbd.Filters.Add(new CommonFileDialogFilter
+                {
+                    DisplayName = "视频或字幕文件",
+                    ShowExtensions = false
+                });
                 var result = fbd.ShowDialog();
 
                 if (result == CommonFileDialogResult.Ok && fbd.FileNames.Count() > 0)
@@ -418,5 +427,7 @@ namespace SubRenamer
             string args = $"/select, \"{filePath}\"";
             Process.Start("explorer.exe", args);
         }
+
+
     }
 }

--- a/SubRenamer/Properties/Resources.Designer.cs
+++ b/SubRenamer/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SubRenamer.Properties {
     // 类通过类似于 ResGen 或 Visual Studio 的工具自动生成的。
     // 若要添加或移除成员，请编辑 .ResX 文件，然后重新运行 ResGen
     // (以 /str 作为命令选项)，或重新生成 VS 项目。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -47,8 +47,8 @@ namespace SubRenamer.Properties {
         }
         
         /// <summary>
-        ///   重写当前线程的 CurrentUICulture 属性
-        ///   重写当前线程的 CurrentUICulture 属性。
+        ///   重写当前线程的 CurrentUICulture 属性，对
+        ///   使用此强类型资源类的所有资源查找执行重写。
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
         internal static global::System.Globalization.CultureInfo Culture {

--- a/SubRenamer/Properties/Settings.Designer.cs
+++ b/SubRenamer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace SubRenamer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/SubRenamer/SettingForm.Designer.cs
+++ b/SubRenamer/SettingForm.Designer.cs
@@ -40,6 +40,14 @@
             this.BlogLabel = new System.Windows.Forms.LinkLabel();
             this.RenameVideo = new System.Windows.Forms.CheckBox();
             this.label2 = new System.Windows.Forms.Label();
+            this.listBoxVideoExtension = new System.Windows.Forms.ListBox();
+            this.listBoxSubExtension = new System.Windows.Forms.ListBox();
+            this.labelVideoExtension = new System.Windows.Forms.Label();
+            this.labelSubExtension = new System.Windows.Forms.Label();
+            this.btnAddVideoExtension = new System.Windows.Forms.Button();
+            this.btnDeleteVideoExtension = new System.Windows.Forms.Button();
+            this.btnDeleteSubExtension = new System.Windows.Forms.Button();
+            this.btnAddSubExtension = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // VersionText
@@ -49,7 +57,7 @@
             this.VersionText.ForeColor = System.Drawing.SystemColors.ControlDarkDark;
             this.VersionText.Location = new System.Drawing.Point(643, 300);
             this.VersionText.Name = "VersionText";
-            this.VersionText.Size = new System.Drawing.Size(92, 30);
+            this.VersionText.Size = new System.Drawing.Size(46, 16);
             this.VersionText.TabIndex = 16;
             this.VersionText.Text = "v0.0.0.0";
             // 
@@ -58,7 +66,7 @@
             this.UpdateLinkLabel.AutoSize = true;
             this.UpdateLinkLabel.Location = new System.Drawing.Point(583, 299);
             this.UpdateLinkLabel.Name = "UpdateLinkLabel";
-            this.UpdateLinkLabel.Size = new System.Drawing.Size(62, 31);
+            this.UpdateLinkLabel.Size = new System.Drawing.Size(32, 17);
             this.UpdateLinkLabel.TabIndex = 24;
             this.UpdateLinkLabel.TabStop = true;
             this.UpdateLinkLabel.Text = "更新";
@@ -70,7 +78,7 @@
             this.GithubLinkLabel.AutoSize = true;
             this.GithubLinkLabel.Location = new System.Drawing.Point(200, 299);
             this.GithubLinkLabel.Name = "GithubLinkLabel";
-            this.GithubLinkLabel.Size = new System.Drawing.Size(110, 31);
+            this.GithubLinkLabel.Size = new System.Drawing.Size(56, 17);
             this.GithubLinkLabel.TabIndex = 23;
             this.GithubLinkLabel.TabStop = true;
             this.GithubLinkLabel.Text = "开源仓库";
@@ -82,7 +90,7 @@
             this.AuthorLinkLabel.AutoSize = true;
             this.AuthorLinkLabel.Location = new System.Drawing.Point(77, 299);
             this.AuthorLinkLabel.Name = "AuthorLinkLabel";
-            this.AuthorLinkLabel.Size = new System.Drawing.Size(62, 31);
+            this.AuthorLinkLabel.Size = new System.Drawing.Size(32, 17);
             this.AuthorLinkLabel.TabIndex = 22;
             this.AuthorLinkLabel.TabStop = true;
             this.AuthorLinkLabel.Text = "作者";
@@ -94,7 +102,7 @@
             this.linkLabel1.AutoSize = true;
             this.linkLabel1.Location = new System.Drawing.Point(17, 299);
             this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.Size = new System.Drawing.Size(62, 31);
+            this.linkLabel1.Size = new System.Drawing.Size(32, 17);
             this.linkLabel1.TabIndex = 21;
             this.linkLabel1.TabStop = true;
             this.linkLabel1.Text = "反馈";
@@ -108,7 +116,7 @@
             this.label1.ForeColor = System.Drawing.SystemColors.ControlDark;
             this.label1.Location = new System.Drawing.Point(47, 52);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(471, 28);
+            this.label1.Size = new System.Drawing.Size(248, 16);
             this.label1.TabIndex = 15;
             this.label1.Text = "改名前备份到相同目录下的 SubBackup 文件夹中";
             // 
@@ -118,7 +126,7 @@
             this.RawSubtitleBuckup.Font = new System.Drawing.Font("微软雅黑", 8F);
             this.RawSubtitleBuckup.Location = new System.Drawing.Point(22, 20);
             this.RawSubtitleBuckup.Name = "RawSubtitleBuckup";
-            this.RawSubtitleBuckup.Size = new System.Drawing.Size(221, 34);
+            this.RawSubtitleBuckup.Size = new System.Drawing.Size(114, 20);
             this.RawSubtitleBuckup.TabIndex = 2;
             this.RawSubtitleBuckup.Text = "备份原始字幕文件";
             this.RawSubtitleBuckup.UseVisualStyleBackColor = true;
@@ -129,7 +137,7 @@
             this.ListShowFileFullName.Font = new System.Drawing.Font("微软雅黑", 8F);
             this.ListShowFileFullName.Location = new System.Drawing.Point(22, 130);
             this.ListShowFileFullName.Name = "ListShowFileFullName";
-            this.ListShowFileFullName.Size = new System.Drawing.Size(221, 34);
+            this.ListShowFileFullName.Size = new System.Drawing.Size(114, 20);
             this.ListShowFileFullName.TabIndex = 4;
             this.ListShowFileFullName.Text = "显示文件完整路径";
             this.ListShowFileFullName.UseVisualStyleBackColor = true;
@@ -141,7 +149,7 @@
             this.ListItemRemovePrompt.Font = new System.Drawing.Font("微软雅黑", 8F);
             this.ListItemRemovePrompt.Location = new System.Drawing.Point(22, 95);
             this.ListItemRemovePrompt.Name = "ListItemRemovePrompt";
-            this.ListItemRemovePrompt.Size = new System.Drawing.Size(221, 34);
+            this.ListItemRemovePrompt.Size = new System.Drawing.Size(114, 20);
             this.ListItemRemovePrompt.TabIndex = 3;
             this.ListItemRemovePrompt.Text = "显示各种删除提示";
             this.ListItemRemovePrompt.UseVisualStyleBackColor = true;
@@ -151,7 +159,7 @@
             this.BlogLabel.AutoSize = true;
             this.BlogLabel.Location = new System.Drawing.Point(137, 299);
             this.BlogLabel.Name = "BlogLabel";
-            this.BlogLabel.Size = new System.Drawing.Size(65, 31);
+            this.BlogLabel.Size = new System.Drawing.Size(35, 17);
             this.BlogLabel.TabIndex = 25;
             this.BlogLabel.TabStop = true;
             this.BlogLabel.Text = "Blog";
@@ -164,7 +172,7 @@
             this.RenameVideo.Font = new System.Drawing.Font("微软雅黑", 8F);
             this.RenameVideo.Location = new System.Drawing.Point(22, 203);
             this.RenameVideo.Name = "RenameVideo";
-            this.RenameVideo.Size = new System.Drawing.Size(331, 34);
+            this.RenameVideo.Size = new System.Drawing.Size(169, 20);
             this.RenameVideo.TabIndex = 26;
             this.RenameVideo.Text = "修改视频文件名（根据字幕）";
             this.RenameVideo.UseVisualStyleBackColor = true;
@@ -177,16 +185,100 @@
             this.label2.ForeColor = System.Drawing.SystemColors.ControlDark;
             this.label2.Location = new System.Drawing.Point(47, 230);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(537, 28);
+            this.label2.Size = new System.Drawing.Size(282, 16);
             this.label2.TabIndex = 27;
             this.label2.Text = "通常是修改字幕文件名，勾选根据字幕来修改视频文件名";
             // 
+            // listBoxVideoExtension
+            // 
+            this.listBoxVideoExtension.FormattingEnabled = true;
+            this.listBoxVideoExtension.ItemHeight = 17;
+            this.listBoxVideoExtension.Location = new System.Drawing.Point(423, 61);
+            this.listBoxVideoExtension.Name = "listBoxVideoExtension";
+            this.listBoxVideoExtension.Size = new System.Drawing.Size(120, 208);
+            this.listBoxVideoExtension.TabIndex = 28;
+            // 
+            // listBoxSubExtension
+            // 
+            this.listBoxSubExtension.FormattingEnabled = true;
+            this.listBoxSubExtension.ItemHeight = 17;
+            this.listBoxSubExtension.Location = new System.Drawing.Point(549, 61);
+            this.listBoxSubExtension.Name = "listBoxSubExtension";
+            this.listBoxSubExtension.Size = new System.Drawing.Size(120, 208);
+            this.listBoxSubExtension.TabIndex = 29;
+            // 
+            // labelVideoExtension
+            // 
+            this.labelVideoExtension.AutoSize = true;
+            this.labelVideoExtension.Location = new System.Drawing.Point(420, 9);
+            this.labelVideoExtension.Name = "labelVideoExtension";
+            this.labelVideoExtension.Size = new System.Drawing.Size(68, 17);
+            this.labelVideoExtension.TabIndex = 30;
+            this.labelVideoExtension.Text = "视频扩展名";
+            // 
+            // labelSubExtension
+            // 
+            this.labelSubExtension.AutoSize = true;
+            this.labelSubExtension.Location = new System.Drawing.Point(547, 9);
+            this.labelSubExtension.Name = "labelSubExtension";
+            this.labelSubExtension.Size = new System.Drawing.Size(68, 17);
+            this.labelSubExtension.TabIndex = 31;
+            this.labelSubExtension.Text = "字幕扩展名";
+            // 
+            // btnAddVideoExtension
+            // 
+            this.btnAddVideoExtension.Location = new System.Drawing.Point(423, 32);
+            this.btnAddVideoExtension.Name = "btnAddVideoExtension";
+            this.btnAddVideoExtension.Size = new System.Drawing.Size(43, 23);
+            this.btnAddVideoExtension.TabIndex = 32;
+            this.btnAddVideoExtension.Text = "+";
+            this.btnAddVideoExtension.UseVisualStyleBackColor = true;
+            this.btnAddVideoExtension.Click += new System.EventHandler(this.AddVideoExtension);
+            // 
+            // btnDeleteVideoExtension
+            // 
+            this.btnDeleteVideoExtension.Location = new System.Drawing.Point(472, 32);
+            this.btnDeleteVideoExtension.Name = "btnDeleteVideoExtension";
+            this.btnDeleteVideoExtension.Size = new System.Drawing.Size(43, 23);
+            this.btnDeleteVideoExtension.TabIndex = 33;
+            this.btnDeleteVideoExtension.Text = "-";
+            this.btnDeleteVideoExtension.UseVisualStyleBackColor = true;
+            this.btnDeleteVideoExtension.Click += new System.EventHandler(this.DeleteVideoExtension);
+            // 
+            // btnDeleteSubExtension
+            // 
+            this.btnDeleteSubExtension.Location = new System.Drawing.Point(598, 32);
+            this.btnDeleteSubExtension.Name = "btnDeleteSubExtension";
+            this.btnDeleteSubExtension.Size = new System.Drawing.Size(43, 23);
+            this.btnDeleteSubExtension.TabIndex = 35;
+            this.btnDeleteSubExtension.Text = "-";
+            this.btnDeleteSubExtension.UseVisualStyleBackColor = true;
+            this.btnDeleteSubExtension.Click += new System.EventHandler(this.DeleteSubExtension);
+            // 
+            // btnAddSubExtension
+            // 
+            this.btnAddSubExtension.Location = new System.Drawing.Point(549, 32);
+            this.btnAddSubExtension.Name = "btnAddSubExtension";
+            this.btnAddSubExtension.Size = new System.Drawing.Size(43, 23);
+            this.btnAddSubExtension.TabIndex = 34;
+            this.btnAddSubExtension.Text = "+";
+            this.btnAddSubExtension.UseVisualStyleBackColor = true;
+            this.btnAddSubExtension.Click += new System.EventHandler(this.AddSubExtension);
+            // 
             // SettingForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(14F, 31F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.ClientSize = new System.Drawing.Size(737, 346);
+            this.Controls.Add(this.btnDeleteSubExtension);
+            this.Controls.Add(this.btnAddSubExtension);
+            this.Controls.Add(this.btnDeleteVideoExtension);
+            this.Controls.Add(this.btnAddVideoExtension);
+            this.Controls.Add(this.labelSubExtension);
+            this.Controls.Add(this.labelVideoExtension);
+            this.Controls.Add(this.listBoxSubExtension);
+            this.Controls.Add(this.listBoxVideoExtension);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.RenameVideo);
             this.Controls.Add(this.BlogLabel);
@@ -228,5 +320,13 @@
         private System.Windows.Forms.LinkLabel BlogLabel;
         private System.Windows.Forms.CheckBox RenameVideo;
         private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.ListBox listBoxVideoExtension;
+        private System.Windows.Forms.ListBox listBoxSubExtension;
+        private System.Windows.Forms.Label labelVideoExtension;
+        private System.Windows.Forms.Label labelSubExtension;
+        private System.Windows.Forms.Button btnAddVideoExtension;
+        private System.Windows.Forms.Button btnDeleteVideoExtension;
+        private System.Windows.Forms.Button btnDeleteSubExtension;
+        private System.Windows.Forms.Button btnAddSubExtension;
     }
 }

--- a/SubRenamer/SettingForm.cs
+++ b/SubRenamer/SettingForm.cs
@@ -1,11 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
+﻿using MS.WindowsAPICodePack.Internal;
+using SubRenamer.Lib;
+using System;
 using System.Diagnostics;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace SubRenamer
@@ -64,6 +60,65 @@ namespace SubRenamer
         private void RenameVideo_CheckedChanged(object sender, EventArgs e)
         {
             _mainForm.RefreshFileListUi();
+        }
+
+        public void LoadDefaultExtensions()
+        {
+            foreach (var i in Global.VideoExts) listBoxVideoExtension.Items.Add(i);
+            foreach (var i in Global.SubExts) listBoxSubExtension.Items.Add(i);
+
+        }
+
+        private void AddVideoExtension(object sender, EventArgs e)
+        {
+            string input = "";
+            var result = InputBox.Input("输入视频扩展名（以.开头）", "", ref input);
+            if (result.Equals(DialogResult.Cancel)) return;
+            input = input.Trim();
+            if (!input.StartsWith("."))
+            {
+                MessageBox.Show("请以.开头！");
+                return;
+            }
+            Global.VideoExts.Add(input);
+            listBoxVideoExtension.Items.Add(input);
+        }
+
+        private void DeleteVideoExtension(object sender, EventArgs e)
+        {
+            if (listBoxVideoExtension.Items.Count > 0)
+            {
+                Global.VideoExts.Remove(listBoxVideoExtension.SelectedItem.ToString());
+                listBoxVideoExtension.Items.RemoveAt(listBoxVideoExtension.SelectedIndex);
+                if (listBoxVideoExtension.Items.Count > 0)
+                    listBoxVideoExtension.SelectedIndex = 0;
+            }
+        }
+
+        private void AddSubExtension(object sender, EventArgs e)
+        {
+            string input = "";
+            var result = InputBox.Input("输入字幕扩展名（以.开头）", "", ref input);
+            if (result.Equals(DialogResult.Cancel)) return;
+            input = input.Trim();
+            if (!input.StartsWith("."))
+            {
+                MessageBox.Show("请以.开头！");
+                return;
+            }
+            Global.SubExts.Add(input);
+            listBoxSubExtension.Items.Add(input);
+        }
+
+        private void DeleteSubExtension(object sender, EventArgs e)
+        {
+            if (listBoxSubExtension.Items.Count > 0)
+            {
+                Global.SubExts.Remove(listBoxSubExtension.SelectedItem.ToString());
+                listBoxSubExtension.Items.RemoveAt(listBoxSubExtension.SelectedIndex);
+                if (listBoxSubExtension.Items.Count > 0)
+                    listBoxSubExtension.SelectedIndex = 0;
+            }
         }
     }
 }

--- a/SubRenamer/SettingForm.cs
+++ b/SubRenamer/SettingForm.cs
@@ -1,7 +1,7 @@
-﻿using MS.WindowsAPICodePack.Internal;
-using SubRenamer.Lib;
+﻿using SubRenamer.Lib;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace SubRenamer
@@ -62,11 +62,12 @@ namespace SubRenamer
             _mainForm.RefreshFileListUi();
         }
 
-        public void LoadDefaultExtensions()
+        public void LoadExtensions()
         {
+            foreach (var i in AppSettings.GetExtensionList(AppSettings.GetStringVal(null, "VedioExtension"))) if (i != null && i != "") Global.VideoExts.Add(i);
+            foreach (var i in AppSettings.GetExtensionList(AppSettings.GetStringVal(null, "SubExtension"))) if (i != null && i != "") Global.SubExts.Add(i);
             foreach (var i in Global.VideoExts) listBoxVideoExtension.Items.Add(i);
             foreach (var i in Global.SubExts) listBoxSubExtension.Items.Add(i);
-
         }
 
         private void AddVideoExtension(object sender, EventArgs e)
@@ -81,7 +82,11 @@ namespace SubRenamer
                 return;
             }
             Global.VideoExts.Add(input);
-            listBoxVideoExtension.Items.Add(input);
+            if (!listBoxVideoExtension.Items.Contains(input))
+            {
+                listBoxVideoExtension.Items.Add(input);
+            }
+            AppSettings.IniFile.Write("VedioExtension", string.Join("|", Global.VideoExts.ToArray()));
         }
 
         private void DeleteVideoExtension(object sender, EventArgs e)
@@ -92,6 +97,7 @@ namespace SubRenamer
                 listBoxVideoExtension.Items.RemoveAt(listBoxVideoExtension.SelectedIndex);
                 if (listBoxVideoExtension.Items.Count > 0)
                     listBoxVideoExtension.SelectedIndex = 0;
+                AppSettings.IniFile.Write("VedioExtension", string.Join("|", Global.VideoExts.ToArray()));
             }
         }
 
@@ -107,7 +113,11 @@ namespace SubRenamer
                 return;
             }
             Global.SubExts.Add(input);
-            listBoxSubExtension.Items.Add(input);
+            if (!listBoxSubExtension.Items.Contains(input))
+            {
+                listBoxSubExtension.Items.Add(input);
+            }
+            AppSettings.IniFile.Write("SubExtension", string.Join("|", Global.SubExts.ToArray()));
         }
 
         private void DeleteSubExtension(object sender, EventArgs e)
@@ -118,6 +128,7 @@ namespace SubRenamer
                 listBoxSubExtension.Items.RemoveAt(listBoxSubExtension.SelectedIndex);
                 if (listBoxSubExtension.Items.Count > 0)
                     listBoxSubExtension.SelectedIndex = 0;
+                AppSettings.IniFile.Write("SubExtension", string.Join("|", Global.SubExts.ToArray()));
             }
         }
     }

--- a/SubRenamer/Settings.cs
+++ b/SubRenamer/Settings.cs
@@ -1,0 +1,28 @@
+﻿namespace SubRenamer.Properties {
+    
+    
+    // 通过此类可以处理设置类的特定事件: 
+    //  在更改某个设置的值之前将引发 SettingChanging 事件。
+    //  在更改某个设置的值之后将引发 PropertyChanged 事件。
+    //  在加载设置值之后将引发 SettingsLoaded 事件。
+    //  在保存设置值之前将引发 SettingsSaving 事件。
+    internal sealed partial class Settings {
+        
+        public Settings() {
+            // // 若要为保存和更改设置添加事件处理程序，请取消注释下列行: 
+            //
+            // this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            // this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // 在此处添加用于处理 SettingChangingEvent 事件的代码。
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // 在此处添加用于处理 SettingsSaving 事件的代码。
+        }
+    }
+}

--- a/SubRenamer/SubRenamer.csproj
+++ b/SubRenamer/SubRenamer.csproj
@@ -9,7 +9,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>SubRenamer</RootNamespace>
     <AssemblyName>SubRenamer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/SubRenamer/SubRenamer.csproj
+++ b/SubRenamer/SubRenamer.csproj
@@ -97,6 +97,7 @@
     </Compile>
     <Compile Include="AppSettings.cs" />
     <Compile Include="Global.cs" />
+    <Compile Include="Lib\InputBox.cs" />
     <Compile Include="Lib\IniFile.cs" />
     <Compile Include="Lib\Ui.cs" />
     <Compile Include="Lib\Utils.cs" />

--- a/SubRenamer/SubRenamer.csproj
+++ b/SubRenamer/SubRenamer.csproj
@@ -119,6 +119,7 @@
     <Compile Include="MatchModeEditor\RegexEditor.Designer.cs">
       <DependentUpon>RegexEditor.cs</DependentUpon>
     </Compile>
+    <Compile Include="Settings.cs" />
     <Compile Include="VsItem.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>

--- a/SubRenamer/VsItemEditor.cs
+++ b/SubRenamer/VsItemEditor.cs
@@ -86,7 +86,7 @@ namespace SubRenamer
             Sub_TextBox.SelectionStart = Sub_TextBox.Text.Length;
         }
 
-        private string OpenFileSelectDialog(List<string> exts)
+        private string OpenFileSelectDialog(HashSet<string> exts)
         {
             using (var fbd = new CommonOpenFileDialog()
             {

--- a/SubRenamer/app.config
+++ b/SubRenamer/app.config
@@ -3,12 +3,12 @@
   <configSections>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
   <runtime>
-    <AppContextSwitchOverrides value="Switch.System.Windows.DoNotScaleForDpiChanges=false"  />
+    <AppContextSwitchOverrides value="Switch.System.Windows.DoNotScaleForDpiChanges=false"/>
   </runtime>
   <System.Windows.Forms.ApplicationConfigurationSection>
-    <add key="DpiAwareness" value="PerMonitorV2" />
+    <add key="DpiAwareness" value="PerMonitorV2"/>
   </System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>


### PR DESCRIPTION
![image](https://github.com/qwqcode/SubRenamer/assets/70057922/092add1a-b126-4b7c-951d-97266620f7c0)
原来的自动匹配是判断结尾字符的，这会导致匹配出错，将匹配键值裁剪为只有数字可以初步解决这一问题
![image](https://github.com/qwqcode/SubRenamer/assets/70057922/2f9b3022-7ec0-4364-9982-7ec4abe94689)

flv格式似乎是由于少了一个点导致无法识别，加上后就可以识别了