### PR TITLE
bugfix:Fix the bug of Chinese characters appearing in key

### DIFF
--- a/SubRenamer/Matcher/Diff.cs
+++ b/SubRenamer/Matcher/Diff.cs
@@ -67,7 +67,7 @@ public static class Diff
 
         return "";
 
-        bool IsSymbol(char c) => !char.IsLetterOrDigit(c) && c != ' '; // skip whitespace
+        bool IsSymbol(char c) => !char.IsAsciiLetterOrDigit(c) && c != ' '; // skip whitespace
     }
     
     public static string? ExtractMatchKeyByDiff(DiffResult? diff, string filename)


### PR DESCRIPTION
当导入下面两个文件时匹配出来的key是"01話"和"02話"，正常应该匹配出来1和2
`[Snow-Raws] Angel Beats! 第01話 (BD 1920x1080 HEVC-YUV420P10 FLACx2).mkv`
`[Snow-Raws] Angel Beats! 第02話 (BD 1920x1080 HEVC-YUV420P10 FLACx2).mkv`
![image](https://github.com/qwqcode/SubRenamer/assets/61152132/4b1c326e-9188-42c2-bdf4-4f28c9987603)
导致这个bug的原因是 char.IsLetterOrDigit 这个函数当传入的参数是 '話' 时返回的结果是 true