### PR TITLE
Feature：将改名后的字幕文件复制到视频路径下

### DIFF
--- a/SubRenamer/Common/RenameStrategy.cs
+++ b/SubRenamer/Common/RenameStrategy.cs
@@ -1,0 +1,6 @@
+﻿namespace SubRenamer.Common;
+public enum RenameStrategy
+{
+    Copy,       // Copy the renamed subtitle file to the folder where the video is located
+    Directly    // Directly modify the file name of the selected subtitle file
+}

--- a/SubRenamer/Config.cs
+++ b/SubRenamer/Config.cs
@@ -12,7 +12,8 @@ public partial class Config
     public ThemeMode ThemeMode { get; set; } = ThemeMode.Default;
     public bool Backup { get; set; } = true;
     public bool UpdateCheck { get; set; } = true;
-    
+
+    public RenameStrategy RenameStrategy { get; set; } = RenameStrategy.Copy;
     public string VideoExtAppend { get; set; } = "";
     public string SubtitleExtAppend { get; set; } = "";
     

--- a/SubRenamer/Helper/FileHelper.cs
+++ b/SubRenamer/Helper/FileHelper.cs
@@ -15,7 +15,12 @@ public static class FileHelper
     {
         File.Move(originPath, alterPath);
     }
-    
+
+    public static void CopyFile(string originPath, string alterPath)
+    {
+        File.Copy(originPath, alterPath);
+    }
+
     public static void BackupFile(string path, string folderName = "SubtitleBackup")
     {
         // create new 'SubtitleBackup' directory if not exists

--- a/SubRenamer/Matcher/Diff.cs
+++ b/SubRenamer/Matcher/Diff.cs
@@ -67,7 +67,7 @@ public static class Diff
 
         return "";
 
-        bool IsSymbol(char c) => !char.IsLetterOrDigit(c) && c != ' '; // skip whitespace
+        bool IsSymbol(char c) => !char.IsAsciiLetterOrDigit(c) && c != ' '; // skip whitespace
     }
     
     public static string? ExtractMatchKeyByDiff(DiffResult? diff, string filename)

--- a/SubRenamer/Services/RenameService.cs
+++ b/SubRenamer/Services/RenameService.cs
@@ -21,9 +21,16 @@ public class RenameService(Window target) : IRenameService
         {
             if (string.IsNullOrEmpty(item.Subtitle) || string.IsNullOrEmpty(item.Video)) continue;
 
-            var alter = Path.GetDirectoryName(item.Subtitle) +
-                        "/" + Path.GetFileNameWithoutExtension(item.Video) +
+            var alter = "/" + Path.GetFileNameWithoutExtension(item.Video) +
                         Path.GetExtension(item.Subtitle);
+
+            if(Config.Get().RenameStrategy == Common.RenameStrategy.Copy)
+            {
+                alter = Path.GetDirectoryName(item.Video) + alter;
+            } else
+            {
+                alter = Path.GetDirectoryName(item.Subtitle) + alter;
+            }
 
             destList.Add(new RenameTask(item.Subtitle, alter, item.Status == "已修改" ? "已修改" : "待修改")
             {
@@ -41,9 +48,14 @@ public class RenameService(Window target) : IRenameService
             
             try
             {
-                if (Config.Get().Backup) FileHelper.BackupFile(task.Origin);
-                FileHelper.RenameFile(task.Origin, task.Alter);
-                
+                if (Config.Get().RenameStrategy == Common.RenameStrategy.Copy)
+                {
+                    FileHelper.CopyFile(task.Origin, task.Alter);
+                } else
+                {
+                    if (Config.Get().Backup) FileHelper.BackupFile(task.Origin);
+                    FileHelper.RenameFile(task.Origin, task.Alter);
+                }
                 task.Status = "已修改";
                 if (task.MatchItem != null) task.MatchItem.Status = "已修改";
             }

--- a/SubRenamer/ViewModels/SettingsViewModel.cs
+++ b/SubRenamer/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,7 @@ using SubRenamer.Services;
 using Microsoft.Extensions.DependencyInjection;
 using SubRenamer.Helper;
 using SubRenamer.Model;
+using SubRenamer.Common;
 
 namespace SubRenamer.ViewModels;
 
@@ -20,6 +21,17 @@ public partial class SettingsViewModel : ViewModelBase
     private bool _updateCheckEnabled = Config.Get().UpdateCheck;
     private string _videoExtAppend = Config.Get().VideoExtAppend;
     private string _subtitleExtAppend = Config.Get().SubtitleExtAppend;
+    private RenameStrategy _renameStrategy = Config.Get().RenameStrategy;
+
+    public RenameStrategy RenameStrategy
+    {
+        get => _renameStrategy;
+        set
+        {
+            Config.Get().RenameStrategy = value;
+            SetProperty(ref _renameStrategy, value);
+        }
+    }
 
     public bool BackupEnabled
     {

--- a/SubRenamer/Views/SettingsWindow.axaml
+++ b/SubRenamer/Views/SettingsWindow.axaml
@@ -3,6 +3,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:SubRenamer.ViewModels"
+		xmlns:helper="clr-namespace:SubRenamer.Helper"
+		xmlns:common="clr-namespace:SubRenamer.Common"
         mc:Ignorable="d"
         WindowStartupLocation="CenterOwner"
         Width="500"
@@ -10,60 +12,78 @@
         x:Class="SubRenamer.Views.SettingsWindow"
         x:DataType="vm:SettingsViewModel"
         Title="设置">
-        
-        <Design.DataContext>
-                <vm:SettingsViewModel/>
-        </Design.DataContext>
-        
-        <Window.Styles>
-                <Style Selector="Button.hyperlink">
-                        <Setter Property="Template">
-                                <ControlTemplate>
-                                        <TextBlock Text="{TemplateBinding Content}" Foreground="{StaticResource SystemAccentColor}" TextDecorations="Underline">
-                                                <TextBlock.Styles>
-                                                        <Style Selector="TextBlock:pointerover">
-                                                                <Setter Property="Foreground" Value="{StaticResource SystemAccentColorLight1}"/>
-                                                        </Style>
-                                                </TextBlock.Styles>
-                                        </TextBlock>
-                                </ControlTemplate>
-                        </Setter>
-                        <Setter Property="Background" Value="Transparent"/>
-                        <Setter Property="BorderThickness" Value="0"/>
-                </Style>     
-        </Window.Styles>
-        
-        <StackPanel Margin="20">
-                <CheckBox IsChecked="{Binding BackupEnabled}">备份原始文件</CheckBox>
-                <Label Foreground="Gray" Margin="20 0 20 10">（备份字幕文件到 SubBackup 文件夹中）</Label>
-                <!-- <CheckBox>确认删除对话框</CheckBox> -->
-                <!-- <CheckBox>显示文件完整路径</CheckBox> -->
-                <CheckBox IsChecked="{Binding UpdateCheckEnabled}">程序升级检查</CheckBox>
-                <Border Height="15" />
-                <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
-                        <StackPanel Grid.Column="0">
-                                <TextBlock Margin="0 5">视频格式扩充</TextBlock>
-                                <TextBox Watermark="以逗号分隔" Text="{Binding VideoExtAppend}" />
-                        </StackPanel>
-                        <StackPanel Grid.Column="2">
-                                <TextBlock Margin="0 5">字幕格式扩充</TextBlock>
-                                <TextBox Watermark="以逗号分隔" Text="{Binding SubtitleExtAppend}" />  
-                        </StackPanel>
-                </Grid>
-                
-                <Border Height="30" />
-                <TextBlock TextWrapping="Wrap" FontSize="13" LineHeight="24" Foreground="#5f6b7c">
-                        |´・ω・)ノ 嗨！这是开源程序<LineBreak />
-                        你可以在 <Button Classes="hyperlink" Content="GitHub" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer" /> 找到源代码，请考虑点个 Star 🌟这会对我们很有帮助！
-                </TextBlock>
-                
-                <Border Height="5" />
-                <Border BorderThickness=".5" BorderBrush="#D2D4D5"></Border>
-                
-                <Border Height="15" />
-                <StackPanel Orientation="Horizontal" Spacing="15">
-                        <Button Classes="hyperlink" Content="反馈问题" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/issues/new" />
-                        <Button Classes="hyperlink" Content="更新日志" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/releases" />
-                </StackPanel>
-        </StackPanel>
+
+	<Design.DataContext>
+		<vm:SettingsViewModel/>
+	</Design.DataContext>
+
+	<Window.Resources>
+		<helper:EnumToBooleanConverter x:Key="EnumBoolConverter"/>
+	</Window.Resources>
+
+	<Window.Styles>
+		<Style Selector="Button.hyperlink">
+			<Setter Property="Template">
+				<ControlTemplate>
+					<TextBlock Text="{TemplateBinding Content}" Foreground="{StaticResource SystemAccentColor}" TextDecorations="Underline">
+						<TextBlock.Styles>
+							<Style Selector="TextBlock:pointerover">
+								<Setter Property="Foreground" Value="{StaticResource SystemAccentColorLight1}"/>
+							</Style>
+						</TextBlock.Styles>
+					</TextBlock>
+				</ControlTemplate>
+			</Setter>
+			<Setter Property="Background" Value="Transparent"/>
+			<Setter Property="BorderThickness" Value="0"/>
+		</Style>
+	</Window.Styles>
+
+	<StackPanel Margin="20">
+		<Canvas HorizontalAlignment="Left">
+			<TextBlock  Canvas.Left="12" Canvas.Top="-5" Height="14" TextWrapping="Wrap" FontSize="11" FontWeight="Bold" LineHeight="24" Foreground="#5f6b7c" Background="White">
+				重命名设置
+			</TextBlock>
+		</Canvas>
+		<Border ZIndex="-1" CornerRadius="3" BorderThickness=".5" BorderBrush="#D2D4D5" Padding="5 0 0 0">
+			<StackPanel>
+				<RadioButton IsChecked="{Binding RenameStrategy, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static common:RenameStrategy.Copy}}" GroupName="howToRename" Content="将改名后的字幕文件复制到视频路径下" Margin="0 5 0 0"/>
+				<RadioButton IsChecked="{Binding RenameStrategy, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static common:RenameStrategy.Directly}}" GroupName="howToRename" Content="直接重命名字幕文件"/>
+				<TextBlock IsVisible="{Binding RenameStrategy, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static common:RenameStrategy.Directly}}">
+					<CheckBox IsChecked="{Binding BackupEnabled}" Margin="30 0 20 0">备份原始文件</CheckBox>
+					<Label VerticalAlignment="Center" Margin="-30 0 0 0" HorizontalAlignment="Left" Foreground="Gray">（备份字幕文件到 SubBackup 文件夹中）</Label>					
+				</TextBlock>
+			</StackPanel>
+		</Border>
+		<Border Height="5" />
+		<!-- <CheckBox>确认删除对话框</CheckBox> -->
+		<!-- <CheckBox>显示文件完整路径</CheckBox> -->
+		<CheckBox IsChecked="{Binding UpdateCheckEnabled}">程序升级检查</CheckBox>
+		<Border Height="15" />
+		<Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
+			<StackPanel Grid.Column="0">
+				<TextBlock Margin="0 5">视频格式扩充</TextBlock>
+				<TextBox Watermark="以逗号分隔" Text="{Binding VideoExtAppend}" />
+			</StackPanel>
+			<StackPanel Grid.Column="2">
+				<TextBlock Margin="0 5">字幕格式扩充</TextBlock>
+				<TextBox Watermark="以逗号分隔" Text="{Binding SubtitleExtAppend}" />
+			</StackPanel>
+		</Grid>
+
+		<Border Height="30" />
+		<TextBlock TextWrapping="Wrap" FontSize="13" LineHeight="24" Foreground="#5f6b7c">
+			|´・ω・)ノ 嗨！这是开源程序<LineBreak />
+			你可以在 <Button Classes="hyperlink" Content="GitHub" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer" /> 找到源代码，请考虑点个 Star 🌟这会对我们很有帮助！
+		</TextBlock>
+
+		<Border Height="5" />
+		<Border BorderThickness=".5" BorderBrush="#D2D4D5"></Border>
+
+		<Border Height="15" />
+		<StackPanel Orientation="Horizontal" Spacing="15">
+			<Button Classes="hyperlink" Content="反馈问题" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/issues/new" />
+			<Button Classes="hyperlink" Content="更新日志" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/releases" />
+		</StackPanel>
+	</StackPanel>
 </Window>


### PR DESCRIPTION
SubRenamer 的 v0.5.2.2021-7-10 版本中一键改名的逻辑是将改名后的字幕文件复制到视频所在的路径下，但是不知道为什么到 2.0.0版本一键改名就变成了直接改字幕文件的名称，这样会需要用户将改名好后的字幕再复制或移动到视频所在的路径下，多了一个操作步骤，挺麻烦的。其次如果没有选择备份，原有字幕文件的名称已经改变，不利于二次传播；如果选择了备份字幕路径下会多出来一个文件夹，挺别扭的。
    所以在设置界面新加了一个单选按钮，可以选择是复制还是直接改字幕的名字。效果如下：
![image](https://github.com/qwqcode/SubRenamer/assets/61152132/75e8d178-edd8-4392-9045-7f108c0ab90b)
当选择“直接重命名字幕文件”时“备份原始文件”才会显示。
你也可以直接去下我的 release 看看实际效果