### PR TITLE
perf: improve renaming strategy

### DIFF
--- a/SubRenamer/Common/RenameStrategy.cs
+++ b/SubRenamer/Common/RenameStrategy.cs
@@ -1,6 +1,0 @@
-﻿namespace SubRenamer.Common;
-public enum RenameStrategy
-{
-    Copy,       // Copy the renamed subtitle file to the folder where the video is located
-    Directly    // Directly modify the file name of the selected subtitle file
-}

--- a/SubRenamer/Config.cs
+++ b/SubRenamer/Config.cs
@@ -12,8 +12,7 @@ public partial class Config
     public ThemeMode ThemeMode { get; set; } = ThemeMode.Default;
     public bool Backup { get; set; } = true;
     public bool UpdateCheck { get; set; } = true;
-
-    public RenameStrategy RenameStrategy { get; set; } = RenameStrategy.Copy;
+    
     public string VideoExtAppend { get; set; } = "";
     public string SubtitleExtAppend { get; set; } = "";
     

--- a/SubRenamer/ViewModels/SettingsViewModel.cs
+++ b/SubRenamer/ViewModels/SettingsViewModel.cs
@@ -11,7 +11,6 @@ using SubRenamer.Services;
 using Microsoft.Extensions.DependencyInjection;
 using SubRenamer.Helper;
 using SubRenamer.Model;
-using SubRenamer.Common;
 
 namespace SubRenamer.ViewModels;
 
@@ -21,17 +20,6 @@ public partial class SettingsViewModel : ViewModelBase
     private bool _updateCheckEnabled = Config.Get().UpdateCheck;
     private string _videoExtAppend = Config.Get().VideoExtAppend;
     private string _subtitleExtAppend = Config.Get().SubtitleExtAppend;
-    private RenameStrategy _renameStrategy = Config.Get().RenameStrategy;
-
-    public RenameStrategy RenameStrategy
-    {
-        get => _renameStrategy;
-        set
-        {
-            Config.Get().RenameStrategy = value;
-            SetProperty(ref _renameStrategy, value);
-        }
-    }
 
     public bool BackupEnabled
     {

--- a/SubRenamer/Views/SettingsWindow.axaml
+++ b/SubRenamer/Views/SettingsWindow.axaml
@@ -3,8 +3,6 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="using:SubRenamer.ViewModels"
-		xmlns:helper="clr-namespace:SubRenamer.Helper"
-		xmlns:common="clr-namespace:SubRenamer.Common"
         mc:Ignorable="d"
         WindowStartupLocation="CenterOwner"
         Width="500"
@@ -12,78 +10,62 @@
         x:Class="SubRenamer.Views.SettingsWindow"
         x:DataType="vm:SettingsViewModel"
         Title="设置">
-
-	<Design.DataContext>
-		<vm:SettingsViewModel/>
-	</Design.DataContext>
-
-	<Window.Resources>
-		<helper:EnumToBooleanConverter x:Key="EnumBoolConverter"/>
-	</Window.Resources>
-
-	<Window.Styles>
-		<Style Selector="Button.hyperlink">
-			<Setter Property="Template">
-				<ControlTemplate>
-					<TextBlock Text="{TemplateBinding Content}" Foreground="{StaticResource SystemAccentColor}" TextDecorations="Underline">
-						<TextBlock.Styles>
-							<Style Selector="TextBlock:pointerover">
-								<Setter Property="Foreground" Value="{StaticResource SystemAccentColorLight1}"/>
-							</Style>
-						</TextBlock.Styles>
-					</TextBlock>
-				</ControlTemplate>
-			</Setter>
-			<Setter Property="Background" Value="Transparent"/>
-			<Setter Property="BorderThickness" Value="0"/>
-		</Style>
-	</Window.Styles>
-
-	<StackPanel Margin="20">
-		<Canvas HorizontalAlignment="Left">
-			<TextBlock  Canvas.Left="12" Canvas.Top="-5" Height="14" TextWrapping="Wrap" FontSize="11" FontWeight="Bold" LineHeight="24" Foreground="#5f6b7c" Background="White">
-				重命名设置
-			</TextBlock>
-		</Canvas>
-		<Border ZIndex="-1" CornerRadius="3" BorderThickness=".5" BorderBrush="#D2D4D5" Padding="5 0 0 0">
-			<StackPanel>
-				<RadioButton IsChecked="{Binding RenameStrategy, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static common:RenameStrategy.Copy}}" GroupName="howToRename" Content="将改名后的字幕文件复制到视频路径下" Margin="0 5 0 0"/>
-				<RadioButton IsChecked="{Binding RenameStrategy, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static common:RenameStrategy.Directly}}" GroupName="howToRename" Content="直接重命名字幕文件"/>
-				<TextBlock IsVisible="{Binding RenameStrategy, Converter={StaticResource EnumBoolConverter}, ConverterParameter={x:Static common:RenameStrategy.Directly}}">
-					<CheckBox IsChecked="{Binding BackupEnabled}" Margin="30 0 20 0">备份原始文件</CheckBox>
-					<Label VerticalAlignment="Center" Margin="-30 0 0 0" HorizontalAlignment="Left" Foreground="Gray">（备份字幕文件到 SubBackup 文件夹中）</Label>					
-				</TextBlock>
-			</StackPanel>
-		</Border>
-		<Border Height="5" />
-		<!-- <CheckBox>确认删除对话框</CheckBox> -->
-		<!-- <CheckBox>显示文件完整路径</CheckBox> -->
-		<CheckBox IsChecked="{Binding UpdateCheckEnabled}">程序升级检查</CheckBox>
-		<Border Height="15" />
-		<Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
-			<StackPanel Grid.Column="0">
-				<TextBlock Margin="0 5">视频格式扩充</TextBlock>
-				<TextBox Watermark="以逗号分隔" Text="{Binding VideoExtAppend}" />
-			</StackPanel>
-			<StackPanel Grid.Column="2">
-				<TextBlock Margin="0 5">字幕格式扩充</TextBlock>
-				<TextBox Watermark="以逗号分隔" Text="{Binding SubtitleExtAppend}" />
-			</StackPanel>
-		</Grid>
-
-		<Border Height="30" />
-		<TextBlock TextWrapping="Wrap" FontSize="13" LineHeight="24" Foreground="#5f6b7c">
-			|´・ω・)ノ 嗨！这是开源程序<LineBreak />
-			你可以在 <Button Classes="hyperlink" Content="GitHub" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer" /> 找到源代码，请考虑点个 Star 🌟这会对我们很有帮助！
-		</TextBlock>
-
-		<Border Height="5" />
-		<Border BorderThickness=".5" BorderBrush="#D2D4D5"></Border>
-
-		<Border Height="15" />
-		<StackPanel Orientation="Horizontal" Spacing="15">
-			<Button Classes="hyperlink" Content="反馈问题" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/issues/new" />
-			<Button Classes="hyperlink" Content="更新日志" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/releases" />
-		</StackPanel>
-	</StackPanel>
+        
+        <Design.DataContext>
+                <vm:SettingsViewModel/>
+        </Design.DataContext>
+        
+        <Window.Styles>
+                <Style Selector="Button.hyperlink">
+                        <Setter Property="Template">
+                                <ControlTemplate>
+                                        <TextBlock Text="{TemplateBinding Content}" Foreground="{StaticResource SystemAccentColor}" TextDecorations="Underline">
+                                                <TextBlock.Styles>
+                                                        <Style Selector="TextBlock:pointerover">
+                                                                <Setter Property="Foreground" Value="{StaticResource SystemAccentColorLight1}"/>
+                                                        </Style>
+                                                </TextBlock.Styles>
+                                        </TextBlock>
+                                </ControlTemplate>
+                        </Setter>
+                        <Setter Property="Background" Value="Transparent"/>
+                        <Setter Property="BorderThickness" Value="0"/>
+                </Style>     
+        </Window.Styles>
+        
+        <StackPanel Margin="20">
+                <CheckBox IsChecked="{Binding BackupEnabled}">备份原始字幕</CheckBox>
+                <Label Foreground="Gray" Margin="30 0 30 10" FontSize="13" Padding="0">程序会复制字幕到视频目录，若目录相同则备份到 SubBackup</Label>
+                <!-- <CheckBox>确认删除对话框</CheckBox> -->
+                <!-- <CheckBox>显示文件完整路径</CheckBox> -->
+                <CheckBox IsChecked="{Binding UpdateCheckEnabled}">程序升级检查</CheckBox>
+                <Border Height="15" />
+                <Grid HorizontalAlignment="Stretch" ColumnDefinitions="*,10,*">
+                        <StackPanel Grid.Column="0">
+                                <TextBlock Margin="0 5">视频格式扩充</TextBlock>
+                                <Label Foreground="Gray" Margin="0 0 0 10" Padding="0" FontSize="13">用于识别视频文件</Label>
+                                <TextBox Watermark="以逗号分隔" Text="{Binding VideoExtAppend}" />
+                        </StackPanel>
+                        <StackPanel Grid.Column="2">
+                                <TextBlock Margin="0 5">字幕格式扩充</TextBlock>
+                                <Label Foreground="Gray" Margin="0 0 0 10" Padding="0" FontSize="13">用于识别字幕文件</Label>
+                                <TextBox Watermark="以逗号分隔" Text="{Binding SubtitleExtAppend}" />  
+                        </StackPanel>
+                </Grid>
+                
+                <Border Height="30" />
+                <TextBlock TextWrapping="Wrap" FontSize="13" LineHeight="24" Foreground="#5f6b7c">
+                        |´・ω・)ノ 嗨！这是开源程序<LineBreak />
+                        你可以在 <Button Classes="hyperlink" Content="GitHub" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer" /> 找到源代码，请考虑点个 Star 🌟这会对我们很有帮助！
+                </TextBlock>
+                
+                <Border Height="5" />
+                <Border BorderThickness=".5" BorderBrush="#D2D4D5"></Border>
+                
+                <Border Height="15" />
+                <StackPanel Orientation="Horizontal" Spacing="15">
+                        <Button Classes="hyperlink" Content="反馈问题" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/issues/new" />
+                        <Button Classes="hyperlink" Content="更新日志" Command="{Binding OpenLinkCommand}" CommandParameter="https://github.com/qwqcode/SubRenamer/releases" />
+                </StackPanel>
+        </StackPanel>
 </Window>


### PR DESCRIPTION
基于 #47，修改手动切换命名策略为自动模式：

- 当视频文件和字幕文件位于 **相同** 文件夹中时策略为 “**原地修改字幕文件名**”（并备份原始字幕到 SubBackup 目录）
- 当视频文件和字幕文件位于 **不同** 文件夹中时策略为 “**复制字幕副本到视频文件夹内**”（无需备份）

简化操作，减轻用户心智负担。

fix #51