### PR TITLE
refactor: optimize Matcher algorithm

### DIFF
--- a/SubRenamer/Helper/MatcherDataConverter.cs
+++ b/SubRenamer/Helper/MatcherDataConverter.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SubRenamer.Helper;
+
+public static class MatcherDataConverter
+{
+    public static List<Matcher.MatchItem> ConvertMatchItems(IReadOnlyList<Model.MatchItem> matchItems)
+    {
+        return matchItems.Select(item => new Matcher.MatchItem(item.Key, item.Video, item.Subtitle)).ToList();
+    }
+    
+    public static List<Model.MatchItem> ConvertMatchItems(IReadOnlyList<Matcher.MatchItem> matchItems)
+    {
+        return matchItems.Select(item => new Model.MatchItem(item.Key, item.Video, item.Subtitle)).ToList();
+    }
+}

--- a/SubRenamer/Matcher/Helper.cs
+++ b/SubRenamer/Matcher/Helper.cs
@@ -3,19 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using SubRenamer.Helper;
-using SubRenamer.Model;
 
 namespace SubRenamer.Matcher;
 
 public static class Helper
 {
-    public static string? ExtractMatchKeyRegex(string pattern, string filename)
+    public static string ExtractMatchKeyRegex(string pattern, string filename)
     {
         try {
             var match = Regex.Match(filename, pattern, RegexOptions.IgnoreCase);
             if (match.Success) return match.Groups[1].Value;
         } catch (Exception e) {
-            Console.WriteLine(e.Message);
+            Logger.Out.WriteLine(e.Message);
         }
         return "";
     }
@@ -42,18 +41,17 @@ public static class Helper
         }
     }
 
-    public static void MoveEmptyKeyItemsToLast(List<MatchItem> items)
+    public static List<MatchItem> MoveEmptyKeyItemsToLast(IReadOnlyList<MatchItem> items)
     {
-        var emptyKeyItems = items.Where(x => string.IsNullOrEmpty(x.Key)).ToList();
-        foreach (var item in emptyKeyItems)
-        {
-            items.Remove(item);
-            items.Add(item);
-        }
+        var keyedItems = items.Where(x => !string.IsNullOrEmpty(x.Key));
+        var emptyKeyItems = items.Where(x => string.IsNullOrEmpty(x.Key));
+        return [..keyedItems, ..emptyKeyItems];
     }
 
-    public static void SortItemsByKeys(List<MatchItem> items)
+    public static List<MatchItem> SortItemsByKeys(IReadOnlyList<MatchItem> items)
     {
-        items.Sort((a, b) => new MixedStringComparer().Compare(a.Key, b.Key));
+        List<MatchItem> result = [..items];
+        result.Sort((a, b) => new MixedStringComparer().Compare(a.Key, b.Key));
+        return result;
     }
 }

--- a/SubRenamer/Matcher/Logger.cs
+++ b/SubRenamer/Matcher/Logger.cs
@@ -1,0 +1,10 @@
+using System;
+using System.IO;
+
+namespace SubRenamer.Matcher;
+
+public static class Logger
+{
+    public static TextWriter Out { get; private set; } = Console.Out;
+    public static void SetWriter(TextWriter writer) => Out = writer;
+}

--- a/SubRenamer/Matcher/Matcher.cs
+++ b/SubRenamer/Matcher/Matcher.cs
@@ -1,87 +1,90 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using SubRenamer.Common;
-using SubRenamer.Model;
 
 namespace SubRenamer.Matcher;
 
+public record MatchItem(string Key, string Video, string Subtitle);
+
 public static class Matcher
 {
-    public static List<MatchItem> Execute(IReadOnlyList<MatchItem> matchItems)
+    public static List<MatchItem> Execute(IReadOnlyList<MatchItem> inputItems)
     {
         // Create new collection
-        var items = new List<MatchItem>();
-        var videoFiles = new List<string>();
-        var subtitleFiles = new List<string>();
-        
+        List<MatchItem> result = [];
+        List<string> videoFiles = [];
+        List<string> subtitleFiles = [];
+
         // Separate Video files and Subtitle files
-        matchItems.Where(x => !string.IsNullOrEmpty(x.Video)).ToList().ForEach(item =>
+        inputItems.Where(x => !string.IsNullOrEmpty(x.Video)).ToList().ForEach(item =>
         {
-            items.Add(new MatchItem("", item.Video, "", ""));
+            result.Add(new MatchItem("", item.Video, ""));
             videoFiles.Add(item.Video);
         });
-        
-        matchItems.Where(x => !string.IsNullOrEmpty(x.Subtitle)).ToList().ForEach(item =>
+
+        inputItems.Where(x => !string.IsNullOrEmpty(x.Subtitle)).ToList().ForEach(item =>
         {
-            items.Add(new MatchItem("", "", item.Subtitle, ""));
+            result.Add(new MatchItem("", "", item.Subtitle));
             subtitleFiles.Add(item.Subtitle);
         });
-        
+
         // Get file keys
         var m = Config.Get().MatchMode;
         var videoRegex = (m != MatchMode.Diff) ? (m == MatchMode.Manual ? Config.Get().ManualVideoRegex : Config.Get().VideoRegex) : null;
         var subtitleRegex = (m != MatchMode.Diff) ? (m == MatchMode.Manual ? Config.Get().ManualSubtitleRegex : Config.Get().SubtitleRegex) : null;
-        
+
         var video2Keys = CalculateFileKeys(videoFiles, videoRegex);
         var subtitle2Keys = CalculateFileKeys(subtitleFiles, subtitleRegex);
-        
+
         // Apply keys
-        foreach (var item in items)
+        List<MatchItem> keyedItems = [];
+        foreach (var item in result)
         {
             string? k = null;
-            
+
             if (!string.IsNullOrEmpty(item.Video)) video2Keys.TryGetValue(item.Video, out k);
             else if (!string.IsNullOrEmpty(item.Subtitle)) subtitle2Keys.TryGetValue(item.Subtitle, out k);
 
-            item.Key = k ?? "";
+            keyedItems.Add(new MatchItem(k ?? "", item.Video, item.Subtitle));
         }
-        
-        // Merge items with same keys
-        Helper.MergeSameKeysItems(items);
-        
-        // Sort
-        Helper.SortItemsByKeys(items);
-        
-        // Move empty keys to last
-        Helper.MoveEmptyKeyItemsToLast(items);
 
-        return items;
+        result = keyedItems;
+
+        // Merge items with same keys
+        result = Helper.MergeSameKeysItems(result);
+
+        // Sort
+        result = Helper.SortItemsByKeys(result);
+
+        // Move empty keys to last
+        result = Helper.MoveEmptyKeyItemsToLast(result);
+
+        return result;
     }
-    
-    private static Dictionary<string, string?> CalculateFileKeys(List<string> files, string? regexPattern)
+
+    private static Dictionary<string, string> CalculateFileKeys(IReadOnlyList<string> files, string? regexPattern)
     {
-        var dict = new Dictionary<string, string?>();
-        
+        var result = new Dictionary<string, string>();
+
         if (regexPattern is null)
         {
             // 1. Auto Diff Algorithm
-            
+
             // Diff filenames
             var names = files
                 .Select(Path.GetFileNameWithoutExtension)
                 .Where(x => !string.IsNullOrEmpty(x))
                 .Distinct()
                 .ToList();
-        
+
             var diff = Diff.GetDiffResult(names!);
-        
+            Logger.Out.WriteLine("[Diff.GetDiffResult]\n\n  {0}\n", (diff != null ? diff : "null"));
+
             // Extract Match keys
             foreach (var f in files)
             {
-                var key = Diff.ExtractMatchKeyByDiff(diff, Path.GetFileNameWithoutExtension(f));
-                dict[f] = key;
+                result[f] = Diff.ExtractMatchKeyByDiff(diff, Path.GetFileNameWithoutExtension(f));
             }
         }
         else
@@ -89,11 +92,10 @@ public static class Matcher
             // 2. Regex Algorithm
             foreach (var f in files)
             {
-                var key = Helper.ExtractMatchKeyRegex(regexPattern, Path.GetFileName(f));
-                dict[f] = key;
+                result[f] = Helper.ExtractMatchKeyRegex(regexPattern, Path.GetFileName(f));
             }
         }
 
-        return dict;
+        return result;
     }
 }

--- a/SubRenamer/Model/IRenameService.cs
+++ b/SubRenamer/Model/IRenameService.cs
@@ -5,7 +5,7 @@ namespace SubRenamer.Model;
 
 public interface IRenameService
 {
-    void UpdateRenameTaskList(IEnumerable<MatchItem> matchList, Collection<RenameTask> destList);
-    void ExecuteRename(IEnumerable<RenameTask> taskList);
-    string GenerateRenameCommands(IEnumerable<MatchItem> list);
+    void UpdateRenameTaskList(IReadOnlyList<MatchItem> matchList, Collection<RenameTask> destList);
+    void ExecuteRename(IReadOnlyList<RenameTask> taskList);
+    string GenerateRenameCommands(IReadOnlyList<MatchItem> list);
 }

--- a/SubRenamer/Model/MatchItem.cs
+++ b/SubRenamer/Model/MatchItem.cs
@@ -3,12 +3,12 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SubRenamer.Model;
 
-public partial class MatchItem(string? key = "", string video = "", string subtitle = "", string status = "") : ObservableObject
+public partial class MatchItem(string key = "", string video = "", string subtitle = "", string status = "") : ObservableObject
 {
     /**
      * Match Key
      */
-    [ObservableProperty] private string? _key = key;
+    [ObservableProperty] private string _key = key;
     
     /**
      * Video Absolute Path

--- a/SubRenamer/Services/RenameService.cs
+++ b/SubRenamer/Services/RenameService.cs
@@ -14,7 +14,7 @@ public class RenameService(Window target) : IRenameService
 {
     private readonly Window _target = target;
 
-    public void UpdateRenameTaskList(IEnumerable<MatchItem> matchList, Collection<RenameTask> destList)
+    public void UpdateRenameTaskList(IReadOnlyList<MatchItem> matchList, Collection<RenameTask> destList)
     {
         destList.Clear();
 
@@ -42,7 +42,7 @@ public class RenameService(Window target) : IRenameService
         }
     }
 
-    public void ExecuteRename(IEnumerable<RenameTask> taskList)
+    public void ExecuteRename(IReadOnlyList<RenameTask> taskList)
     {
         foreach (var task in taskList)
         {
@@ -78,7 +78,7 @@ public class RenameService(Window target) : IRenameService
         }
     }
 
-    public string GenerateRenameCommands(IEnumerable<MatchItem> list)
+    public string GenerateRenameCommands(IReadOnlyList<MatchItem> list)
     {
         var command = "";
         

--- a/SubRenamer/ViewModels/MainViewModel.cs
+++ b/SubRenamer/ViewModels/MainViewModel.cs
@@ -143,7 +143,9 @@ public partial class MainViewModel : ViewModelBase
     private void PerformMatch()
     {
         ShowRenameTasks = false;
-        var result = Matcher.Matcher.Execute(MatchList.ToList());
+        var inputItems = MatcherDataConverter.ConvertMatchItems(MatchList);
+        var resultRaw = Matcher.Matcher.Execute(inputItems);
+        var result =  MatcherDataConverter.ConvertMatchItems(resultRaw);
         result.ForEach(UpdateMatchItemStatus);
         MatchList = new ObservableCollection<MatchItem>(result);
     }


### PR DESCRIPTION
The PR included:

**Separation of Concerns**

   - Isolated the algorithm logic layer from the view layer by no longer using the `MatchItem` from the `SubRenamer.Model` namespace in the view layer. 
   - Before calling the `Execute` function, the view layer's `MatchItem` is converted to the algorithm layer's `MatchItem` using `MatcherDataConverter.ConvertMatchItems`. After execution, the returned `MatchItem` is converted back to the view layer's format.

**Use of Records**: 

   - Replaced classes with C# 9.0 [Records](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record) for `MatchItem` and `DiffResult` data structures. This change emphasizes immutability, making testing easier.

**Function Behavior**: 

   - Some functions now do not modify the input `List` in place. Instead, they return a new `List` copy. The input is defined as an immutable `IReadOnlyList`, promoting idempotency and simplifying testing.

**Diff Result Calculation**: 

   - The `GetDiffResult` method has been modified to use a double loop, where `i` and `j` approach from both ends towards the center. It prioritizes matching the first and last items instead of adjacent ones. This aims to prevent incorrect `DiffResult` prefixes and suffixes when multiple identical filenames in different languages are encountered.

**Improvements to FindCommonSuffix**: 

   - The input value `Prefix` has been removed from `FindCommonSuffix`.
   - The algorithm has been improved to use a two-pointer approach to skip over non-matching characters.

**Type and Variable Modifications**: 

   - Various types have been modified, and some variable names have been renamed for clarity.